### PR TITLE
fix: 代码优化

### DIFF
--- a/src/runtime-core/renderer.ts
+++ b/src/runtime-core/renderer.ts
@@ -93,7 +93,7 @@ export function createRenderer(options) {
 
     if (shapeFlag & ShapeFlags.TEXT_CHILDREN) {
       if (prevShapeFlag & ShapeFlags.ARRAY_CHILDREN) {
-        unmountChildren(n1.children);
+        unmountChildren(c1);
       }
       if (c1 !== c2) {
         hostSetElementText(container, c2);


### PR DESCRIPTION
代码优化 将unmountChildren函数中传入的实参 n1.children 用已经声明的变量 c1 代替